### PR TITLE
doc: avoid infinite recursion in hmModule

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Using `flake.nix`:
         {
           home-manager.users.exampleUser = lib.mkMerge [
             nix-doom-emacs.hmModule
-            { pkgs, ... }: {
+            { ... }: {
               programs.doom-emacs = {
                 enable = true;
                 doomPrivateDir = ./doom.d;

--- a/README.md
+++ b/README.md
@@ -52,22 +52,25 @@ Using `flake.nix`:
   outputs = {
     self,
     nixpkgs,
+    lib,
     home-manager,
     nix-doom-emacs,
     ...
   }: {
-    nixosConfigurations.exampleHost = nixpkgs.lib.nixosSystem {
+    nixosConfigurations.exampleHost = lib.nixosSystem {
       system = "x86_64-linux";
       modules = [
         home-manager.nixosModules.home-manager
         {
-          home-manager.users.exampleUser = { pkgs, ... }: {
-            imports = [ nix-doom-emacs.hmModule ];
-            programs.doom-emacs = {
-              enable = true;
-              doomPrivateDir = ./doom.d;
-            };
-          };
+          home-manager.users.exampleUser = lib.mkMerge [
+            nix-doom-emacs.hmModule
+            { pkgs, ... }: {
+              programs.doom-emacs = {
+                enable = true;
+                doomPrivateDir = ./doom.d;
+              };
+            }
+          ];
         }
       ];
     };


### PR DESCRIPTION
when adding the home manager module to my HM config, i see:

```
error: infinite recursion encountered

       at /nix/store/g1562lf0ibiwj5d2ahz2prxy6dsxim7r-source/lib/modules.nix:403:28:

          402|         builtins.addErrorContext (context name)
          403|           (args.${name} or config._module.args.${name})
             |                            ^
          404|       ) (lib.functionArgs f);
```

This is discussed at https://github.com/vlaci/nix-doom-emacs/issues/157.

It occurs because somewhere in my home derivation, I'm referencing `config` (i think). By keeping modules separate using `mkMerge`, infinite recursion errors can be avoided.