### PR TITLE
Add `sln-mode` flake input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -325,7 +325,8 @@
         "org-yt": "org-yt",
         "php-extras": "php-extras",
         "revealjs": "revealjs",
-        "rotate-text": "rotate-text"
+        "rotate-text": "rotate-text",
+        "sln-mode": "sln-mode"
       }
     },
     "rotate-text": {
@@ -341,6 +342,22 @@
       "original": {
         "owner": "debug-ito",
         "repo": "rotate-text.el",
+        "type": "github"
+      }
+    },
+    "sln-mode": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1423727528,
+        "narHash": "sha256-XqkqPyEJuTtFslOz1fpTf/Klbd/zA7IGpzpmum/MGao=",
+        "owner": "sensorflo",
+        "repo": "sln-mode",
+        "rev": "0f91d1b957c7d2a7bab9278ec57b54d57f1dbd9c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sensorflo",
+        "repo": "sln-mode",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -70,6 +70,8 @@
     revealjs.flake = false;
     rotate-text.url = "github:debug-ito/rotate-text.el";
     rotate-text.flake = false;
+    sln-mode.url = "github:sensorflo/sln-mode";
+    sln-mode.flake = false;
     format-all.url =
       "github:lassik/emacs-format-all-the-code/47d862d40a088ca089c92cd393c6dca4628f87d3";
     format-all.flake = false;

--- a/overrides.nix
+++ b/overrides.nix
@@ -98,6 +98,10 @@ self: super: {
     pname = "rotate-text";
   };
 
+  sln-mode = self.straightBuild {
+    pname = "sln-mode";
+  };
+
   so-long = self.straightBuild {
     pname = "emacs-so-long";
     ename = "so-long";


### PR DESCRIPTION
Adds `sln-mode` needed for the `csharp` language as a flake input as it is not available on MELPA.