### PR TITLE
Use `--init-directory` in Emacs 29+

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -36,6 +36,7 @@ jobs:
         fi
     - run: |
         nix build .#checks.x86_64-linux.init-example-el
+        nix build .#checks.x86_64-linux.init-example-el-emacsGit
     - name: Export /nix/store contents
       if: ${{ !steps.cache-nix-store.outputs.cache-hit }}
       run: |

--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -6,8 +6,8 @@ on:
       - master
       - develop
 jobs:
-  check:
-    name: Flake Check (x86_64 only)
+  check-emacs:
+    name: Flake Check emacs (x86_64 only)
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -34,10 +34,43 @@ jobs:
           nix-store --import < nix-store.dump || true
           rm nix-store.dump
         fi
-    - run: |
+    - name: Run checks in emacs
+      run: |
         nix build .#checks.x86_64-linux.init-example-el
-        nix build .#checks.x86_64-linux.init-example-el-emacsGit
     - name: Export /nix/store contents
       if: ${{ !steps.cache-nix-store.outputs.cache-hit }}
+      run: |
+        nix-store --export $(nix-store -qR /nix/store/*-doom-emacs) > nix-store.dump
+  check-emacsGit:
+    name: Flake Check emacsGit (x86_64 only)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+          # Nix Flakes doesn't work on shallow clones
+          fetch-depth: 0
+    - uses: cachix/install-nix-action@v17
+      with:
+        name: nix-community
+    - name: Retrieve /nix/store archive
+      uses: actions/cache@v3
+      id: cache-nix-store-emacsGit
+      with:
+        path: nix-store.dump
+        key: nix-store-emacsGit-${{ hashFiles('flake.*') }}
+        restore-keys: |
+          nix-store-emacsGit-
+    - name: Import /nix/store contents
+      if: ${{ steps.cache-nix-store-emacsGit.outputs.cache-hit }}
+      run: |
+        if [[ -f nix-store.dump ]]; then
+          nix-store --import < nix-store.dump || true
+          rm nix-store.dump
+        fi
+    - name: Run checks in emacsGit
+      run: |
+        nix build .#checks.x86_64-linux.init-example-el-emacsGit
+    - name: Export /nix/store contents
+      if: ${{ !steps.cache-nix-store-emacsGit.outputs.cache-hit }}
       run: |
         nix-store --export $(nix-store -qR /nix/store/*-doom-emacs) > nix-store.dump

--- a/default.nix
+++ b/default.nix
@@ -202,7 +202,7 @@ let
     chmod u+w $out/config.el
     cat $extraConfigPath > $out/config.extra.el
     cat > $out/config.el << EOF
-    (load "${builtins.toString doomPrivateDir}/config.el")
+    (load "${doomPrivateDir}/config.el")
     (load "$out/config.extra.el")
     EOF
   '';
@@ -213,11 +213,10 @@ let
     load-config-from-site = writeTextDir "share/emacs/site-lisp/default.el" ''
       (message "doom-emacs is not placed in `doom-private-dir',
       loading from `site-lisp'")
-    ''
-    # on Emacs 29+ we will use `--init-directory` instead of `default.el`
-    + lib.optionalString (!isEmacs29) ''
+      ${lib.optionalString (!isEmacs29) ''
       (load "${doom-emacs}/early-init.el")
       (load "${doom-emacs}/core/core-start.el")
+      ''}
     '';
   in (emacsPackages.emacsWithPackages (epkgs: [ load-config-from-site ]));
 

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,5 @@
 { # The files would be going to ~/.config/doom (~/.doom.d)
-doomPrivateDir
+  doomPrivateDir
 /* Extra packages to install
 
    Useful for non-emacs packages containing emacs bindings (e.g.
@@ -8,8 +8,7 @@ doomPrivateDir
    Example:
      extraPackages = epkgs: [ pkgs.mu ];
 */
-, extraPackages ? epkgs:
-  [ ]
+, extraPackages ? epkgs: [ ]
   /* Extra configuration to source during initialization
 
      Use this to refer other nix derivations.
@@ -36,8 +35,7 @@ doomPrivateDir
        });
      };
 */
-, emacsPackagesOverlay ? self: super:
-  { }
+, emacsPackagesOverlay ? self: super: { }
   /* Use bundled revision of github.com/nix-community/emacs-overlay
      as `emacsPackages`.
   */
@@ -54,7 +52,8 @@ doomPrivateDir
          "emacs-overlay" = fetchFromGitHub { owner = /* ...*\/; };
        };
   */
-, dependencyOverrides ? { }, lib, pkgs, stdenv, buildEnv, makeWrapper
+, dependencyOverrides ? { }
+, lib, pkgs, stdenv, buildEnv, makeWrapper
 , runCommand, fetchFromGitHub, substituteAll, writeShellScript
 , writeShellScriptBin, writeTextDir }:
 
@@ -63,6 +62,7 @@ assert (lib.assertMsg ((builtins.isPath doomPrivateDir)
   "doomPrivateDir must be either a path, a derivation or a stringified store path");
 
 let
+  isEmacs29 = lib.versionAtLeast emacsPackages.emacs.version "29";
   flake =
     (import
       (let lock = with builtins; fromJSON (readFile ./flake.lock); in
@@ -213,11 +213,29 @@ let
     load-config-from-site = writeTextDir "share/emacs/site-lisp/default.el" ''
       (message "doom-emacs is not placed in `doom-private-dir',
       loading from `site-lisp'")
-      (when (> emacs-major-version 26)
-            (load "${doom-emacs}/early-init.el"))
+    ''
+    # on Emacs 29+ we will use `--init-directory` instead of `default.el`
+    + lib.optionalString (!isEmacs29) ''
+      (load "${doom-emacs}/early-init.el")
       (load "${doom-emacs}/core/core-start.el")
     '';
   in (emacsPackages.emacsWithPackages (epkgs: [ load-config-from-site ]));
+
+  # create a `emacs.d` dir to be loaded using `--init-directory` flag from Emacs 29+
+  # this will allow proper usage of `early-init.el`, fixing FOUC issues and improving
+  # startup performance
+  init-el = pkgs.writeTextDir "emacs.d/init.el" ''
+    (load "${doom-emacs}/core/core-start.el")
+  '';
+
+  early-init-el = pkgs.writeTextDir "emacs.d/early-init.el" ''
+    (load "${doom-emacs}/early-init.el")
+  '';
+
+  emacs-d = pkgs.symlinkJoin {
+    name = "emacs.d";
+    paths = [ early-init-el init-el ];
+  };
 
   build-summary = writeShellScript "build-summary" ''
     printf "\n${fmt.green}Successfully built nix-doom-emacs!${fmt.reset}\n"
@@ -227,13 +245,23 @@ let
   '';
 in emacs.overrideAttrs (esuper:
   let
+    # `--init-directory` is supported by Emacs 29+ only
+    initDirArgs = lib.optionalString isEmacs29 ''
+      if [[ $(basename $1) == emacs ]] || [[ $(basename $1) == emacs-* ]]; then
+        wrapArgs+=(--add-flags '--init-directory ${emacs-d}/emacs.d')
+      fi
+    '';
     cmd = ''
       wrapEmacs() {
-          wrapProgram $1 \
-                    --set DOOMDIR ${doomDir} \
-                    --set NIX_DOOM_EMACS_BINARY $1 \
-                    --set __DEBUG_doom_emacs_DIR ${doom-emacs} \
-                    --set __DEBUG_doomLocal_DIR ${doomLocal}
+          local -a wrapArgs=(
+              --set DOOMDIR ${doomDir}
+              --set NIX_DOOM_EMACS_BINARY $1
+              --set __DEBUG_doom_emacs_DIR ${doom-emacs}
+              --set __DEBUG_doomLocal_DIR ${doomLocal}
+          )
+          ${initDirArgs}
+
+          wrapProgram $1 "''${wrapArgs[@]}"
       }
 
       for prog in $out/bin/*; do

--- a/default.nix
+++ b/default.nix
@@ -209,6 +209,7 @@ let
 
   # Stage 5: catch-all wrapper capable to run doom-emacs even
   # without installing ~/.emacs.d
+  # TODO: remove once Emacs 29+ is released and commonly available
   emacs = let
     load-config-from-site = writeTextDir "share/emacs/site-lisp/default.el" ''
       (message "doom-emacs is not placed in `doom-private-dir',

--- a/default.nix
+++ b/default.nix
@@ -214,8 +214,8 @@ let
       (message "doom-emacs is not placed in `doom-private-dir',
       loading from `site-lisp'")
       ${lib.optionalString (!isEmacs29) ''
-      (load "${doom-emacs}/early-init.el")
-      (load "${doom-emacs}/core/core-start.el")
+        (load "${doom-emacs}/early-init.el")
+        (load "${doom-emacs}/core/core-start.el")
       ''}
     '';
   in (emacsPackages.emacsWithPackages (epkgs: [ load-config-from-site ]));

--- a/default.nix
+++ b/default.nix
@@ -223,11 +223,11 @@ let
   # create a `emacs.d` dir to be loaded using `--init-directory` flag from Emacs 29+
   # this will allow proper usage of `early-init.el`, fixing FOUC issues and improving
   # startup performance
-  init-el = pkgs.writeTextDir "emacs.d/init.el" ''
+  init-el = pkgs.writeTextDir "share/emacs.d/init.el" ''
     (load "${doom-emacs}/core/core-start.el")
   '';
 
-  early-init-el = pkgs.writeTextDir "emacs.d/early-init.el" ''
+  early-init-el = pkgs.writeTextDir "share/emacs.d/early-init.el" ''
     (load "${doom-emacs}/early-init.el")
   '';
 
@@ -247,7 +247,7 @@ in emacs.overrideAttrs (esuper:
     # `--init-directory` is supported by Emacs 29+ only
     initDirArgs = lib.optionalString isEmacs29 ''
       if [[ $(basename $1) == emacs ]] || [[ $(basename $1) == emacs-* ]]; then
-        wrapArgs+=(--add-flags '--init-directory ${emacs-d}/emacs.d')
+        wrapArgs+=(--add-flags '--init-directory ${emacs-d}/share/emacs.d')
       fi
     '';
     cmd = ''

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -91,6 +91,7 @@ in
     in
     mkMerge ([
       {
+        # TODO: remove once Emacs 29+ is released and commonly available
         home.file.".emacs.d/init.el".text = ''
           (load "default.el")
         '';


### PR DESCRIPTION
This will allow a few advantages:
- We can load `early-init.el` file properly, fixing Flash Of Unstyled Contents (FOUC) issues and improving the performance slightly
- Eventually we can drop `default.el` file loading in Home-Manager module. Not done here since this would complicate the code without necessity, however this can be done once Emacs 29+ is default

Alternative for: https://github.com/nix-community/nix-doom-emacs/pull/187
Fix issue: https://github.com/nix-community/nix-doom-emacs/issues/186