### PR TITLE
Trying to fix CI

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -10,17 +10,13 @@ jobs:
     name: Flake Check (x86_64 only)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
           # Nix Flakes doesn't work on shallow clones
           fetch-depth: 0
-    - uses: cachix/install-nix-action@v12
-      with:
-        install_url: https://github.com/numtide/nix-flakes-installer/releases/download/nix-2.4pre20201221_9fab14a/install
-        extra_nix_config: |
-          experimental-features = nix-command flakes
+    - uses: cachix/install-nix-action@v17
     - name: Retrieve /nix/store archive
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: cache-nix-store
       with:
         path: nix-store.dump

--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -15,6 +15,8 @@ jobs:
           # Nix Flakes doesn't work on shallow clones
           fetch-depth: 0
     - uses: cachix/install-nix-action@v17
+      with:
+        name: nix-community
     - name: Retrieve /nix/store archive
       uses: actions/cache@v3
       id: cache-nix-store

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -8,15 +8,11 @@ jobs:
     name: Update dependencies
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
           # Nix Flakes doesn't work on shallow clones
           fetch-depth: 0
-    - uses: cachix/install-nix-action@v12
-      with:
-        install_url: https://github.com/numtide/nix-flakes-installer/releases/download/nix-2.4pre20201221_9fab14a/install
-        extra_nix_config: |
-          experimental-features = nix-command flakes
+    - uses: cachix/install-nix-action@v17
     - name: Create PRs for dependencies
       env:
         GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -41,15 +37,11 @@ jobs:
         git config --global user.email 41898282+github-actions[bot]@users.noreply.github.com
         git config --global init.defaultBranch main
         git config --global pull.rebase false
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
           # Nix Flakes doesn't work on shallow clones
           fetch-depth: 0
-    - uses: cachix/install-nix-action@v12
-      with:
-        install_url: https://github.com/numtide/nix-flakes-installer/releases/download/nix-2.4pre20201221_9fab14a/install
-        extra_nix_config: |
-          experimental-features = nix-command flakes
+    - uses: cachix/install-nix-action@v17
     - name: Run test_dep_update
       env:
         GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -13,6 +13,8 @@ jobs:
           # Nix Flakes doesn't work on shallow clones
           fetch-depth: 0
     - uses: cachix/install-nix-action@v17
+      with:
+        name: nix-community
     - name: Create PRs for dependencies
       env:
         GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -42,6 +44,8 @@ jobs:
           # Nix Flakes doesn't work on shallow clones
           fetch-depth: 0
     - uses: cachix/install-nix-action@v17
+      with:
+        name: nix-community
     - name: Run test_dep_update
       env:
         GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "doom-emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1656519163,
-        "narHash": "sha256-iNg3DnQJB6iIWLBsFGcloFHwwQUgrJeIQeNJHD7nwIo=",
+        "lastModified": 1657023376,
+        "narHash": "sha256-huKtA8twjW3GkfA6NRvCjWMWUEN58ju4sL89rRQxOes=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "c2f8476c8641fcc9a1371d873ed3b5924952a059",
+        "rev": "9ec60d9ab9eb5d9b098e2452395156b622cce624",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     "emacs-overlay": {
       "flake": false,
       "locked": {
-        "lastModified": 1656667522,
-        "narHash": "sha256-20rsPIbX4pihuiBQ0pb/0WrdijUjiHSjgOz1UXhGf68=",
+        "lastModified": 1657218856,
+        "narHash": "sha256-rrAxgrXex2xXV7j2NCbr3cZZvX/Dqa0m28VFWTtvrHo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "46492f286aefae3a4993d3c65f182618f98956e9",
+        "rev": "7c367081f2f47f5ea3d5e18c958856294180256e",
         "type": "github"
       },
       "original": {
@@ -131,11 +131,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1656065134,
-        "narHash": "sha256-oc6E6ByIw3oJaIyc67maaFcnjYOz1mMcOtHxbEf9NwQ=",
+        "lastModified": 1656928814,
+        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "bee6a7250dd1b01844a2de7e02e4df7d8a0a206c",
+        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
         "type": "github"
       },
       "original": {
@@ -179,11 +179,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1656490020,
-        "narHash": "sha256-xonV1ITvAtwtoM58Iaz77mrkkj3NQKvP2QOPYZNiNvs=",
+        "lastModified": 1657177452,
+        "narHash": "sha256-CojBqno3Zbw9/788+kCjRXXornpc4jJGC6RYvTYdVkg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "23488b5815ef60b3084a874f71fdae2dff52e1f7",
+        "rev": "5cbfadba693e0453f3a4090e83fbf845e18d184b",
         "type": "github"
       },
       "original": {
@@ -227,11 +227,11 @@
     "org": {
       "flake": false,
       "locked": {
-        "lastModified": 1656574173,
-        "narHash": "sha256-Qbsa1b/S26ZudQ0XUtV1YB1pVVd7d9ZIo3UFYTQhe5o=",
+        "lastModified": 1657029612,
+        "narHash": "sha256-enwqnerhZVpyQbeX0uKdZ4IVmZieq9ZgCbkDWy1HlNQ=",
         "owner": "emacs-straight",
         "repo": "org-mode",
-        "rev": "381a2ae4dd439b5f246873ae6630c1e303c35287",
+        "rev": "71359820221ec18d27fab28403d4fd3537ca0491",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -243,17 +243,17 @@
     "org-contrib": {
       "flake": false,
       "locked": {
-        "lastModified": 1654411077,
-        "narHash": "sha256-ywXAI+s+D701PvuDEQljDmFWrTPymqustSYVyf3NYRk=",
-        "ref": "refs/heads/master",
-        "rev": "c6aef31ccfc7c4418c3b51e98f7c3bd8e255f5e6",
-        "revCount": 2622,
-        "type": "git",
-        "url": "https://git.sr.ht/~bzg/org-contrib"
+        "lastModified": 1652646857,
+        "narHash": "sha256-IWIShWyVnbwXqGLQaDNvJ0KoepxhIrXWTjPyGPEkQ14=",
+        "owner": "emacsmirror",
+        "repo": "org-contrib",
+        "rev": "c1e0980fd7a57ca2042fd78acfb1dfb5c3bc03fa",
+        "type": "github"
       },
       "original": {
-        "type": "git",
-        "url": "https://git.sr.ht/~bzg/org-contrib"
+        "owner": "emacsmirror",
+        "repo": "org-contrib",
+        "type": "github"
       }
     },
     "org-yt": {

--- a/flake.nix
+++ b/flake.nix
@@ -58,7 +58,7 @@
     nose.flake = false;
     ob-racket.url = "github:xchrishawk/ob-racket";
     ob-racket.flake = false;
-    org-contrib.url = "git+https://git.sr.ht/~bzg/org-contrib";
+    org-contrib.url = "github:emacsmirror/org-contrib";
     org-contrib.flake = false;
     org.url = "github:emacs-straight/org-mode";
     org.flake = false;


### PR DESCRIPTION
- Update GH actions for their latest versions.
  + In special, the newer versions of `install-nix-action` doesn't need any special change to work with Flakes anymore.
- Update org-contrib. Not really necessary, but upstream also did the same change: https://github.com/doomemacs/doomemacs/commit/20b74b79512c1c5e5866a389513c71a032f55d83.
- Regenerate `flake.lock`.
- Add nix-community cache to GH Actions. This should speed up CI a bit.