### PR TITLE
Fix update_flake_lock.py

### DIFF
--- a/.github/workflows/update_flake_lock.py
+++ b/.github/workflows/update_flake_lock.py
@@ -53,7 +53,7 @@ class FlakeLock:
 
 
 def nix_flake_update(repo, flake_input):
-    check_call(["nix", "flake", "update", "--update-input", flake_input], cwd=repo)
+    check_call(["nix", "flake", "lock", "--update-input", flake_input], cwd=repo)
 
 
 def format_change(change: GitCommit, repo):


### PR DESCRIPTION
Broken since PR https://github.com/nix-community/nix-doom-emacs/pull/192.

`nix flake update` command was changed to update the whole `flake.lock` (the equivalent of `nix flake lock --recreate-lock-file`) and build afterwards. `--update-input` flag was moved to the `nix flake lock` instead.