### PR TITLE
Fix nix-community cache on CI

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -16,7 +16,9 @@ jobs:
           fetch-depth: 0
     - uses: cachix/install-nix-action@v17
       with:
-        name: nix-community
+        extra_nix_config: |
+          extra-substituters = https://nix-community.cachix.org
+          extra-trusted-public-keys = nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=
     - name: Retrieve /nix/store archive
       uses: actions/cache@v3
       id: cache-nix-store

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -14,7 +14,9 @@ jobs:
           fetch-depth: 0
     - uses: cachix/install-nix-action@v17
       with:
-        name: nix-community
+        extra_nix_config: |
+          extra-substituters = https://nix-community.cachix.org
+          extra-trusted-public-keys = nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=
     - name: Create PRs for dependencies
       env:
         GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -45,7 +47,9 @@ jobs:
           fetch-depth: 0
     - uses: cachix/install-nix-action@v17
       with:
-        name: nix-community
+        extra_nix_config: |
+          extra-substituters = https://nix-community.cachix.org
+          extra-trusted-public-keys = nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=
     - name: Run test_dep_update
       env:
         GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The documentation of `install-nix-action` for "I want just to put `nix-community` cachix and nothing else" is kinda confusing (they always assume you want to add your private cachix AND nix-community at the same time). And I just discovered that using either `with.name: nix-community` or `with.extraPullNames: nix-community` doesn't work.

So let's configure `nix-community` cachix instance manually. If someone wants to check the public key, it is here: https://app.cachix.org/cache/nix-community