### PR TITLE
Add Home-Manager module check

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -71,6 +71,10 @@ jobs:
     - name: Run checks in Home-Manager module
       run: |
         nix build .#checks.x86_64-linux.home-manager-module
+    - name: Export /nix/store contents
+      if: ${{ !steps.cache-nix-store.outputs.cache-hit }}
+      run: |
+        nix-store --export $(nix-store -qR /nix/store/*-doom-emacs) > nix-store.dump
   check-emacsGit:
     name: Flake Check emacsGit (x86_64 only)
     runs-on: ubuntu-latest

--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -41,6 +41,36 @@ jobs:
       if: ${{ !steps.cache-nix-store.outputs.cache-hit }}
       run: |
         nix-store --export $(nix-store -qR /nix/store/*-doom-emacs) > nix-store.dump
+  check-home-manager:
+    name: Home-Manager module (x86_64 only)
+    needs: check-emacs
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+          # Nix Flakes doesn't work on shallow clones
+          fetch-depth: 0
+    - uses: cachix/install-nix-action@v17
+      with:
+        name: nix-community
+    - name: Retrieve /nix/store archive
+      uses: actions/cache@v3
+      id: cache-nix-store
+      with:
+        path: nix-store.dump
+        key: nix-store-${{ hashFiles('flake.*') }}
+        restore-keys: |
+          nix-store-
+    - name: Import /nix/store contents
+      if: ${{ steps.cache-nix-store.outputs.cache-hit }}
+      run: |
+        if [[ -f nix-store.dump ]]; then
+          nix-store --import < nix-store.dump || true
+          rm nix-store.dump
+        fi
+    - name: Run checks in Home-Manager module
+      run: |
+        nix build .#checks.x86_64-linux.home-manager-module
   check-emacsGit:
     name: Flake Check emacsGit (x86_64 only)
     runs-on: ubuntu-latest

--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -24,7 +24,7 @@ jobs:
       id: cache-nix-store
       with:
         path: nix-store.dump
-        key: nix-store-${{ hashFiles('flake.*') }}
+        key: nix-store-${{ hashFiles('flake.lock') }}
         restore-keys: |
           nix-store-
     - name: Import /nix/store contents
@@ -58,7 +58,7 @@ jobs:
       id: cache-nix-store
       with:
         path: nix-store.dump
-        key: nix-store-${{ hashFiles('flake.*') }}
+        key: nix-store-${{ hashFiles('flake.lock') }}
         restore-keys: |
           nix-store-
     - name: Import /nix/store contents
@@ -87,7 +87,7 @@ jobs:
       id: cache-nix-store-emacsGit
       with:
         path: nix-store.dump
-        key: nix-store-emacsGit-${{ hashFiles('flake.*') }}
+        key: nix-store-emacsGit-${{ hashFiles('flake.lock') }}
         restore-keys: |
           nix-store-emacsGit-
     - name: Import /nix/store contents

--- a/checks.nix
+++ b/checks.nix
@@ -9,6 +9,8 @@ let
     # this means we need to import the overlay in a hack-ish way
     overlays = [ (import emacs-overlay) ];
   };
+  # we are cloning HM here for the same reason as above, to avoid
+  # an extra additional input to be added to flake
   home-manager = pkgs.fetchFromGitHub {
     owner = "nix-community";
     repo = "home-manager";

--- a/checks.nix
+++ b/checks.nix
@@ -1,0 +1,23 @@
+{ system }:
+{ self, nixpkgs, emacs-overlay, ... }@inputs:
+
+let
+  pkgs = import nixpkgs {
+    inherit system;
+    # we are not using emacs-overlay's flake.nix here,
+    # to avoid unnecessary inputs to be added to flake.lock;
+    # this means we need to import the overlay in a hack-ish way
+    overlays = [ (import emacs-overlay) ];
+  };
+in
+{
+  init-example-el = self.outputs.package.${system} {
+    doomPrivateDir = ./test/doom.d;
+    dependencyOverrides = inputs;
+  };
+  init-example-el-emacsGit = self.outputs.package.${system} {
+    doomPrivateDir = ./test/doom.d;
+    dependencyOverrides = inputs;
+    emacsPackages = with pkgs; emacsPackagesFor emacsGit;
+  };
+}

--- a/checks.nix
+++ b/checks.nix
@@ -9,8 +9,29 @@ let
     # this means we need to import the overlay in a hack-ish way
     overlays = [ (import emacs-overlay) ];
   };
+  home-manager = pkgs.fetchFromGitHub {
+    owner = "nix-community";
+    repo = "home-manager";
+    rev = "8160b3b45b8457d58d2b3af2aeb2eb6f47042e0f";
+    sha256 = "sha256-/aN3p2LaRNVXf7w92GWgXq9H5f23YRQPOvsm3BrBqzU=";
+  };
 in
 {
+  home-manager-module = (import "${home-manager}/modules" {
+    inherit pkgs;
+    configuration = {
+      imports = [ self.outputs.hmModule ];
+      home = {
+        username = "nix-doom-emacs";
+        homeDirectory = "/tmp";
+        stateVersion = "22.11";
+      };
+      programs.doom-emacs = {
+        enable = true;
+        doomPrivateDir = ./test/doom.d;
+      };
+    };
+  }).activationPackage;
   init-example-el = self.outputs.package.${system} {
     doomPrivateDir = ./test/doom.d;
     dependencyOverrides = inputs;

--- a/default.nix
+++ b/default.nix
@@ -1,13 +1,13 @@
 { # The files would be going to ~/.config/doom (~/.doom.d)
   doomPrivateDir
-/* Extra packages to install
+  /* Extra packages to install
 
-   Useful for non-emacs packages containing emacs bindings (e.g.
-   mu4e).
+     Useful for non-emacs packages containing emacs bindings (e.g.
+     mu4e).
 
-   Example:
-     extraPackages = epkgs: [ pkgs.mu ];
-*/
+     Example:
+       extraPackages = epkgs: [ pkgs.mu ];
+  */
 , extraPackages ? epkgs: [ ]
   /* Extra configuration to source during initialization
 
@@ -24,17 +24,17 @@
      Only used to get emacs package, if `bundledPackages` is set.
   */
 , emacsPackages
-/* Overlay to customize emacs (elisp) dependencies
+  /* Overlay to customize emacs (elisp) dependencies
 
-   See overrides.nix for addition examples.
+     See overrides.nix for addition examples.
 
-   Example:
-     emacsPackagesOverlay = self: super: {
-       magit-delta = super.magit-delta.overrideAttrs (esuper: {
-         buildInputs = esuper.buildInputs ++ [ pkgs.git ];
-       });
-     };
-*/
+     Example:
+       emacsPackagesOverlay = self: super: {
+         magit-delta = super.magit-delta.overrideAttrs (esuper: {
+           buildInputs = esuper.buildInputs ++ [ pkgs.git ];
+         });
+       };
+  */
 , emacsPackagesOverlay ? self: super: { }
   /* Use bundled revision of github.com/nix-community/emacs-overlay
      as `emacsPackages`.

--- a/flake.nix
+++ b/flake.nix
@@ -99,28 +99,7 @@
         package = { dependencyOverrides ? { }, ... }@args:
           pkgs.callPackage self
           (args // { dependencyOverrides = (inputs // dependencyOverrides); });
-      }) // eachSystem [ "x86_64-linux" "aarch64-darwin" ] (system: {
-        checks =
-          let
-            pkgs = import nixpkgs {
-              inherit system;
-              # we are not using emacs-overlay's flake.nix here,
-              # to avoid unnecessary inputs to be added to flake.lock;
-              # this means we need to import the overlay in a hack-ish way
-              overlays = [ (import emacs-overlay) ];
-            };
-          in
-            {
-              init-example-el = self.outputs.package.${system} {
-                doomPrivateDir = ./test/doom.d;
-                dependencyOverrides = inputs;
-              };
-              init-example-el-emacsGit = self.outputs.package.${system} {
-                doomPrivateDir = ./test/doom.d;
-                dependencyOverrides = inputs;
-                emacsPackages = with pkgs; emacsPackagesFor emacsGit;
-              };
-            };
+        checks = import ./checks.nix { inherit system; } inputs;
       }) // {
         hmModule = import ./modules/home-manager.nix inputs;
       };


### PR DESCRIPTION
- Move all checks to `checks.nix` file
- Allow checks in all default systems (instead of only `x86_64-linux` and `aarch64-darwin`)
- Add check for Home-Manager module, and add it to CI for PRs
- Use `flake.lock` instead of `flake.*` to generate the cache hash in GitHub Actions. This should avoid invalidating the cache in cases where only `flake.nix` is changed

Depends on PR #191.