### PR TITLE
Make wrapEmacs non-hermetic

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -251,10 +251,10 @@ in emacs.overrideAttrs (esuper:
     cmd = ''
       wrapEmacs() {
           local -a wrapArgs=(
-              --set DOOMDIR ${doomDir}
               --set NIX_DOOM_EMACS_BINARY $1
-              --set __DEBUG_doom_emacs_DIR ${doom-emacs}
-              --set __DEBUG_doomLocal_DIR ${doomLocal}
+              --set-default DOOMDIR ${doomDir}
+              --set-default __DEBUG_doom_emacs_DIR ${doom-emacs}
+              --set-default __DEBUG_doomLocal_DIR ${doomLocal}
           )
           ${initDirArgs}
 


### PR DESCRIPTION
This will allow someone to ovewrite doom-emacs runtime environment variables, e.g. `DOOMDIR`, so they can load a modified `doom.d` directory for testing.

Fixes: #203