### PR TITLE
Update doomemacs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -87,10 +87,7 @@ let
     src = lock "doom-emacs";
     phases = [ "unpackPhase" "patchPhase" "installPhase" ];
     patches = [
-      (substituteAll {
-        src = ./patches/fix-paths.patch;
-        private = builtins.toString doomPrivateDir;
-      })
+      ./patches/fix-paths.patch
     ];
     installPhase = ''
       mkdir -p $out

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "doom-emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1659994866,
-        "narHash": "sha256-6lxvYfoPtzvinBHKvuUDpCz44IJpmZMLfLMy5q9UcFk=",
+        "lastModified": 1660594365,
+        "narHash": "sha256-qdv8scMO91kRk1JNyU2el/TO4tC+Uu7N4NiH55PCsuQ=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "b06fd63dcb686045d0c105f93e07f80cb8de6800",
+        "rev": "050624d47532cef18fcb41daa4e626576b00659c",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     "doom-snippets": {
       "flake": false,
       "locked": {
-        "lastModified": 1655900328,
-        "narHash": "sha256-fEYwFxW2sdzNK14DrS92OCGy8KDPZKewrHljnE/RlzQ=",
+        "lastModified": 1659894476,
+        "narHash": "sha256-1arRqlTos5uj6N47N4hyzHMMoUBxsxaZ/NK7iN5A+ZY=",
         "owner": "doomemacs",
         "repo": "snippets",
-        "rev": "6b2bd5a77c536ed414794ecf71d37a60ebd4663e",
+        "rev": "f957f8d195872f19c7ab0a777d592c611e10e9bb",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     "emacs-overlay": {
       "flake": false,
       "locked": {
-        "lastModified": 1659638214,
-        "narHash": "sha256-lXa01G06Ey9qgj+rYN7Nzc53FP3p2UMMnAuxpWXu9Ko=",
+        "lastModified": 1660646704,
+        "narHash": "sha256-jUa09GGeTNuIka6Aaq+fDMHjGO1r/iBghDLxDG/tQcE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a151f9ff5b9fa813ac8918f3a3a67c643e7e2edc",
+        "rev": "b7f322524d077b01f63d413cea4059c5fffaa362",
         "type": "github"
       },
       "original": {
@@ -163,11 +163,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1656928814,
-        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -211,11 +211,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1659606041,
-        "narHash": "sha256-W4/u2ssr3fS4XOtltrsDD9w2kF4jYYZr6JyPGUW2jdI=",
+        "lastModified": 1660639432,
+        "narHash": "sha256-2WDiboOCfB0LhvnDVMXOAr8ZLDfm3WdO54CkoDPwN1A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5f9b871b72b24f066b1a1e189efd0669f2888c49",
+        "rev": "6c6409e965a6c883677be7b9d87a95fab6c3472e",
         "type": "github"
       },
       "original": {
@@ -259,11 +259,11 @@
     "org": {
       "flake": false,
       "locked": {
-        "lastModified": 1659533964,
-        "narHash": "sha256-ipwJjcRzY9iqEjkG4m8EXZ6+8OMdANuXRnSwct2LByQ=",
+        "lastModified": 1660447962,
+        "narHash": "sha256-EShZzaIDe2Dt/9dLTgypvvW809qEggN5ia1Vssmc27M=",
         "owner": "emacs-straight",
         "repo": "org-mode",
-        "rev": "4702a73031c77ba03b480b0848c137d5d8773e07",
+        "rev": "3303a54d74805cdd2b6eda37285f259949f7ba2e",
         "type": "github"
       },
       "original": {
@@ -323,11 +323,11 @@
     "revealjs": {
       "flake": false,
       "locked": {
-        "lastModified": 1653993278,
-        "narHash": "sha256-X43lsjoLBWmttIKj9Jzut0UP0dZlsue3fYbJ3++ojbU=",
+        "lastModified": 1660499724,
+        "narHash": "sha256-BhnEmX+8h0MVol7T4Zr2w53A+AmgzcVirpwHCR/G73U=",
         "owner": "hakimel",
         "repo": "reveal.js",
-        "rev": "039972c730690af7a83a5cb832056a7cc8b565d7",
+        "rev": "b23d15c4304a9a1b72f484171fc97682e5ed85a3",
         "type": "github"
       },
       "original": {
@@ -400,11 +400,11 @@
     "ts-fold": {
       "flake": false,
       "locked": {
-        "lastModified": 1659171920,
-        "narHash": "sha256-/yY3Ph/BE3PFZhnBIQIHkwOW/43phSI7WeoMvU83TG4=",
+        "lastModified": 1660200855,
+        "narHash": "sha256-y2gouqMbu619qPy48HjAuURLReH96zEKdhvmyIoEZuM=",
         "owner": "jcs-elpa",
         "repo": "ts-fold",
-        "rev": "17d131f69a717d7e8cc6d3af9dfa7d2b5e2b78ef",
+        "rev": "f0804a243544fbbf593791e4390d838b5d1187b0",
         "type": "github"
       },
       "original": {

--- a/patches/fix-paths.patch
+++ b/patches/fix-paths.patch
@@ -1,28 +1,14 @@
-From fd75a170a515e35dcbb10b96a484ad1eb9a1a3f0 Mon Sep 17 00:00:00 2001
+From a0cda2c37c6358956ad737e227ae9bd26cdf3d35 Mon Sep 17 00:00:00 2001
 From: Thiago Kenji Okada <thiagokokada@gmail.com>
-Date: Fri, 5 Aug 2022 22:45:00 +0100
-Subject: [PATCH] Fix paths
+Date: Tue, 16 Aug 2022 17:21:16 +0100
+Subject: [PATCH 2/2] Fix paths
 
 ---
- lisp/lib/config.el        | 2 +-
  modules/app/rss/config.el | 4 ++--
- 2 files changed, 3 insertions(+), 3 deletions(-)
+ 1 file changed, 2 insertions(+), 2 deletions(-)
 
-diff --git a/lisp/lib/config.el b/lisp/lib/config.el
-index 92532c0f5..34c6f9156 100644
---- a/lisp/lib/config.el
-+++ b/lisp/lib/config.el
-@@ -19,7 +19,7 @@
- (defun doom/find-file-in-private-config ()
-   "Search for a file in `doom-private-dir'."
-   (interactive)
--  (doom-project-find-file doom-private-dir))
-+  (doom-project-find-file "@private@"))
- 
- ;;;###autoload
- (defun doom/goto-private-init-file ()
 diff --git a/modules/app/rss/config.el b/modules/app/rss/config.el
-index a8078d18f..075a5c8a7 100644
+index a292f4006..fe3dbfa29 100644
 --- a/modules/app/rss/config.el
 +++ b/modules/app/rss/config.el
 @@ -20,8 +20,8 @@ easier to scroll through.")
@@ -37,5 +23,5 @@ index a8078d18f..075a5c8a7 100644
    (setq elfeed-search-filter "@2-week-ago "
          elfeed-show-entry-switch #'pop-to-buffer
 -- 
-2.36.0
+2.37.1
 

--- a/patches/nix-integration.patch
+++ b/patches/nix-integration.patch
@@ -1,23 +1,21 @@
-From 4a98147cd1c74398347900312d9a9b8766c7b632 Mon Sep 17 00:00:00 2001
+From cab39bdbf3d380c3157575f8c98655037a5a8d5f Mon Sep 17 00:00:00 2001
 From: Thiago Kenji Okada <thiagokokada@gmail.com>
-Date: Fri, 29 Jul 2022 10:32:00 +0100
-Subject: [PATCH] Nix integration
+Date: Tue, 16 Aug 2022 17:21:05 +0100
+Subject: [PATCH 1/2] Nix integration
 
 ---
- early-init.el        | 55 +-------------------------------------------
- lisp/doom-cli-lib.el |  2 +-
- lisp/doom.el         | 18 +++++----------
- 3 files changed, 8 insertions(+), 67 deletions(-)
+ early-init.el | 54 +--------------------------------------------------
+ lisp/doom.el  | 10 ++++++----
+ 2 files changed, 7 insertions(+), 57 deletions(-)
 
 diff --git a/early-init.el b/early-init.el
-index 4335f8db1..c6c29cdd5 100644
+index 4335f8db1..78d2817c1 100644
 --- a/early-init.el
 +++ b/early-init.el
-@@ -73,60 +73,7 @@
- ;;
+@@ -74,59 +74,7 @@
  ;;; Detect `user-emacs-directory'
  
--;; Prevent recursive profile processing, in case you're loading a Doom profile.
+ ;; Prevent recursive profile processing, in case you're loading a Doom profile.
 -(unless (boundp 'doom-version)
 -  ;; Not using `command-switch-alist' to process --profile and --init-directory
 -  ;; was intentional. `command-switch-alist' is processed too late at startup to
@@ -75,41 +73,11 @@ index 4335f8db1..c6c29cdd5 100644
  
  
  ;;
-diff --git a/lisp/doom-cli-lib.el b/lisp/doom-cli-lib.el
-index 309a1fa88..97129d7c0 100644
---- a/lisp/doom-cli-lib.el
-+++ b/lisp/doom-cli-lib.el
-@@ -116,7 +116,7 @@ If nil, falls back to less.")
- 
- Only applies if (exit! :pager) or (exit! :pager?) are called.")
- 
--(defvar doom-cli-log-file-format (expand-file-name "logs/cli.%s.%s.%s" doom-local-dir)
-+(defvar doom-cli-log-file-format (expand-file-name "logs/cli.%s.%s.%s" doom-cache-dir)
-   "Where to write any output/log file to.
- 
- Must have two arguments, one for session id and the other for log type.")
 diff --git a/lisp/doom.el b/lisp/doom.el
-index 981190612..26baf8b33 100644
+index 6dbbefb5e..6116445f3 100644
 --- a/lisp/doom.el
 +++ b/lisp/doom.el
-@@ -132,15 +132,7 @@
- (defconst doom-docs-dir (concat doom-emacs-dir "docs/")
-   "Where Doom's documentation files are stored. Must end with a slash.")
- 
--(defconst doom-private-dir
--  (if-let (doomdir (getenv-internal "DOOMDIR"))
--      (expand-file-name (file-name-as-directory doomdir))
--    (or (let ((xdgdir
--               (expand-file-name "doom/"
--                                 (or (getenv-internal "XDG_CONFIG_HOME")
--                                     "~/.config"))))
--          (if (file-directory-p xdgdir) xdgdir))
--        "~/.doom.d/"))
-+(defconst doom-private-dir (expand-file-name (file-name-as-directory (getenv-internal "DOOMDIR")))
-   "Where your private configuration is placed.
- 
- Defaults to ~/.config/doom, ~/.doom.d or the value of the DOOMDIR envvar;
-@@ -209,7 +201,7 @@ downloaded/installed by packages. Must end in a slash.")
+@@ -221,7 +221,7 @@ downloaded/installed by packages. Must end in a slash.")
        (expand-file-name (file-name-as-directory localdir))
      (if doom-profile
          doom-profile-dir
@@ -118,12 +86,12 @@ index 981190612..26baf8b33 100644
    "Root directory for local storage.
  
  Use this as a storage location for this system's installation of Doom Emacs.
-@@ -217,10 +209,11 @@ Use this as a storage location for this system's installation of Doom Emacs.
+@@ -229,10 +229,11 @@ Use this as a storage location for this system's installation of Doom Emacs.
  These files should not be shared across systems. By default, it is used by
- `doom-etc-dir' and `doom-cache-dir'. Must end with a slash.")
+ `doom-data-dir' and `doom-cache-dir'. Must end with a slash.")
  
 +; nix-doom-emacs: This doesn't meet XDG but backwards compatibility is a thing.
- (defconst doom-etc-dir
+ (defconst doom-data-dir
    (if doom-profile
        doom-profile-data-dir
 -    (concat doom-local-dir "etc/"))
@@ -131,7 +99,7 @@ index 981190612..26baf8b33 100644
    "Directory for non-volatile local storage.
  
  Use this for files that don't change much, like server binaries, external
-@@ -229,7 +222,7 @@ dependencies or long-term shared data. Must end with a slash.")
+@@ -241,7 +242,7 @@ dependencies or long-term shared data. Must end with a slash.")
  (defconst doom-cache-dir
    (if doom-profile
        doom-profile-cache-dir
@@ -140,14 +108,16 @@ index 981190612..26baf8b33 100644
    "Directory for volatile local storage.
  
  Use this for files that change often, like cache files. Must end with a slash.")
-@@ -295,6 +288,7 @@ users).")
+@@ -319,7 +320,8 @@ users).")
    ;; Don't store eln files in ~/.emacs.d/eln-cache (where they can easily be
    ;; deleted by 'doom upgrade').
-   (add-to-list 'native-comp-eln-load-path (concat doom-cache-dir "eln/"))
-+  (add-to-list 'native-comp-eln-load-path (concat doom-cache-dir "cache/eln/"))
+   ;; REVIEW Use `startup-redirect-eln-cache' when 28 support is dropped
+-  (add-to-list 'native-comp-eln-load-path (expand-file-name "eln/" doom-cache-dir)))
++  (add-to-list 'native-comp-eln-load-path (expand-file-name "eln/" doom-cache-dir))
++  (add-to-list 'native-comp-eln-load-path (expand-file-name "cache/eln/" doom-cache-dir)))
  
-   (with-eval-after-load 'comp
-     ;; HACK Disable native-compilation for some troublesome packages
+ 
+ ;;
 -- 
-2.36.0
+2.37.1
 


### PR DESCRIPTION
- Update all flake inputs
- Update and simplify patches

Tested and works with both `.#checks.x86_64-linux.init-example-el` and `.#checks.x86_64-linux.init-example-el-emacsGit`.

Fix issue https://github.com/nix-community/nix-doom-emacs/issues/243.
Substitute https://github.com/nix-community/nix-doom-emacs/pull/245.