### PR TITLE
Change storage location for volatile files

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -251,6 +251,7 @@ in emacs.overrideAttrs (esuper:
           local -a wrapArgs=(
               --set NIX_DOOM_EMACS_BINARY $1
               --set-default DOOMDIR ${doomDir}
+              --set-default DOOMLOCALDIR ${doomLocal}
               --set-default __DEBUG_doom_emacs_DIR ${doom-emacs}
               --set-default __DEBUG_doomLocal_DIR ${doomLocal}
           )

--- a/patches/fix-paths.patch
+++ b/patches/fix-paths.patch
@@ -1,4 +1,4 @@
-From a0cda2c37c6358956ad737e227ae9bd26cdf3d35 Mon Sep 17 00:00:00 2001
+From 8e6933c5cf2d512fef9ef72cc21d50ed5875ea9d Mon Sep 17 00:00:00 2001
 From: Thiago Kenji Okada <thiagokokada@gmail.com>
 Date: Tue, 16 Aug 2022 17:21:16 +0100
 Subject: [PATCH 2/2] Fix paths

--- a/patches/nix-integration.patch
+++ b/patches/nix-integration.patch
@@ -1,12 +1,12 @@
-From cab39bdbf3d380c3157575f8c98655037a5a8d5f Mon Sep 17 00:00:00 2001
+From d21ea569995c4a082c3abd2657e26cd6a20a7b3c Mon Sep 17 00:00:00 2001
 From: Thiago Kenji Okada <thiagokokada@gmail.com>
 Date: Tue, 16 Aug 2022 17:21:05 +0100
 Subject: [PATCH 1/2] Nix integration
 
 ---
  early-init.el | 54 +--------------------------------------------------
- lisp/doom.el  | 10 ++++++----
- 2 files changed, 7 insertions(+), 57 deletions(-)
+ lisp/doom.el  |  4 ++--
+ 2 files changed, 3 insertions(+), 55 deletions(-)
 
 diff --git a/early-init.el b/early-init.el
 index 4335f8db1..78d2817c1 100644
@@ -74,50 +74,27 @@ index 4335f8db1..78d2817c1 100644
  
  ;;
 diff --git a/lisp/doom.el b/lisp/doom.el
-index 6dbbefb5e..6116445f3 100644
+index 6dbbefb5e..0566e6743 100644
 --- a/lisp/doom.el
 +++ b/lisp/doom.el
-@@ -221,7 +221,7 @@ downloaded/installed by packages. Must end in a slash.")
-       (expand-file-name (file-name-as-directory localdir))
-     (if doom-profile
-         doom-profile-dir
--      (expand-file-name ".local/" doom-emacs-dir)))
-+      "@local@/"))
-   "Root directory for local storage.
- 
- Use this as a storage location for this system's installation of Doom Emacs.
-@@ -229,10 +229,11 @@ Use this as a storage location for this system's installation of Doom Emacs.
- These files should not be shared across systems. By default, it is used by
- `doom-data-dir' and `doom-cache-dir'. Must end with a slash.")
- 
-+; nix-doom-emacs: This doesn't meet XDG but backwards compatibility is a thing.
+@@ -232,7 +232,7 @@ These files should not be shared across systems. By default, it is used by
  (defconst doom-data-dir
    (if doom-profile
        doom-profile-data-dir
 -    (concat doom-local-dir "etc/"))
-+    "~/.local/doom")
++    "~/.local/share/doom/")
    "Directory for non-volatile local storage.
  
  Use this for files that don't change much, like server binaries, external
-@@ -241,7 +242,7 @@ dependencies or long-term shared data. Must end with a slash.")
+@@ -241,7 +241,7 @@ dependencies or long-term shared data. Must end with a slash.")
  (defconst doom-cache-dir
    (if doom-profile
        doom-profile-cache-dir
 -    (concat doom-local-dir "cache/"))
-+    "~/.cache/doom")
++    "~/.cache/doom/")
    "Directory for volatile local storage.
  
  Use this for files that change often, like cache files. Must end with a slash.")
-@@ -319,7 +320,8 @@ users).")
-   ;; Don't store eln files in ~/.emacs.d/eln-cache (where they can easily be
-   ;; deleted by 'doom upgrade').
-   ;; REVIEW Use `startup-redirect-eln-cache' when 28 support is dropped
--  (add-to-list 'native-comp-eln-load-path (expand-file-name "eln/" doom-cache-dir)))
-+  (add-to-list 'native-comp-eln-load-path (expand-file-name "eln/" doom-cache-dir))
-+  (add-to-list 'native-comp-eln-load-path (expand-file-name "cache/eln/" doom-cache-dir)))
- 
- 
- ;;
 -- 
 2.37.1
 


### PR DESCRIPTION
Fixes #247.

Since we are going to break backwards compatibility anyway, this PR also changes the location of storage from `~/.local/doom` and `~/.cache/doom` to `~/.local/doom/etc` and `~/.local/doom/cache`. This also gives an opportunity to simplify the patches.