### PR TITLE
Use builtins.fetchTarball in checks.nix to avoid IFD

### DIFF
--- a/checks.nix
+++ b/checks.nix
@@ -11,10 +11,8 @@ let
   };
   # we are cloning HM here for the same reason as above, to avoid
   # an extra additional input to be added to flake
-  home-manager = pkgs.fetchFromGitHub {
-    owner = "nix-community";
-    repo = "home-manager";
-    rev = "8160b3b45b8457d58d2b3af2aeb2eb6f47042e0f";
+  home-manager = builtins.fetchTarball {
+    url = "https://github.com/nix-community/home-manager/tarball/8160b3b45b8457d58d2b3af2aeb2eb6f47042e0f";
     sha256 = "sha256-/aN3p2LaRNVXf7w92GWgXq9H5f23YRQPOvsm3BrBqzU=";
   };
 in


### PR DESCRIPTION
After #200, if you tried to run `nix flake show` in this repo, you would get (using nix 2.8):

```
$ nix flake show
git+file:///home/thiagoko/Projects/nix-doom-emacs?ref=master&rev=ae22b4a3fe31ae31b3e8b415889f8c2c5a77d8dc
├───checks
│   ├───aarch64-darwin
error: cannot build '/nix/store/a5dhhm5nhn936q5177nlv3fn3b4jvqly-source.drv' during evaluation because the option 'allow-import-from-derivation' is disabled
(use '--show-trace' to show detailed location information)
```

The issue here is the early evaluation of `pkgs`, because the usage of `pkgs.fetchFromGitHub`. However, this is completely unnecessary, we can just use `builtins.fetchTarball` in its place. This fixes the issue completely:

```
$ nix flake show
git+file:///home/thiagoko/Projects/nix-doom-emacs
├───checks
│   ├───aarch64-darwin
│   │   ├───home-manager-module: derivation 'home-manager-generation'
│   │   ├───init-example-el: derivation 'emacs-with-packages-28.1'
│   │   └───init-example-el-emacsGit: derivation 'emacs-git-with-packages-20220825.0'
│   ├───aarch64-linux
│   │   ├───home-manager-module: derivation 'home-manager-generation'
│   │   ├───init-example-el: derivation 'emacs-with-packages-28.1'
│   │   └───init-example-el-emacsGit: derivation 'emacs-git-with-packages-20220825.0'
│   ├───i686-linux
│   │   ├───home-manager-module: derivation 'home-manager-generation'
│   │   ├───init-example-el: derivation 'emacs-with-packages-28.1'
│   │   └───init-example-el-emacsGit: derivation 'emacs-git-with-packages-20220825.0'
│   ├───x86_64-darwin
│   │   ├───home-manager-module: derivation 'home-manager-generation'
│   │   ├───init-example-el: derivation 'emacs-with-packages-28.1'
│   │   └───init-example-el-emacsGit: derivation 'emacs-git-with-packages-20220825.0'
│   └───x86_64-linux
│       ├───home-manager-module: derivation 'home-manager-generation'
│       ├───init-example-el: derivation 'emacs-with-packages-28.1'
│       └───init-example-el-emacsGit: derivation 'emacs-git-with-packages-20220825.0'
├───devShell
│   ├───aarch64-darwin: development environment 'nix-shell'
│   ├───aarch64-linux: development environment 'nix-shell'
│   ├───i686-linux: development environment 'nix-shell'
│   ├───x86_64-darwin: development environment 'nix-shell'
│   └───x86_64-linux: development environment 'nix-shell'
├───hmModule: unknown
└───package: unknown
```