### PR TITLE
Refactor flake.nix

### DIFF
--- a/checks.nix
+++ b/checks.nix
@@ -2,6 +2,7 @@
 { self, nixpkgs, emacs-overlay, ... }@inputs:
 
 let
+  inherit (self.outputs.packages.${system}) doom-emacs-example;
   pkgs = import nixpkgs {
     inherit system;
     # we are not using emacs-overlay's flake.nix here,
@@ -32,8 +33,8 @@ in
       };
     };
   }).activationPackage;
-  init-example-el = self.outputs.packages.${system}.doom-emacs;
-  init-example-el-emacsGit = self.outputs.packages.${system}.doom-emacs.override {
+  init-example-el = doom-emacs-example;
+  init-example-el-emacsGit = doom-emacs-example.override {
     emacsPackages = with pkgs; emacsPackagesFor emacsGit;
   };
 }

--- a/checks.nix
+++ b/checks.nix
@@ -32,8 +32,8 @@ in
       };
     };
   }).activationPackage;
-  init-example-el = self.outputs.packages.${system}.nix-doom-emacs;
-  init-example-el-emacsGit = self.outputs.packages.${system}.nix-doom-emacs.override {
+  init-example-el = self.outputs.packages.${system}.doom-emacs;
+  init-example-el-emacsGit = self.outputs.packages.${system}.doom-emacs.override {
     emacsPackages = with pkgs; emacsPackagesFor emacsGit;
   };
 }

--- a/checks.nix
+++ b/checks.nix
@@ -32,13 +32,8 @@ in
       };
     };
   }).activationPackage;
-  init-example-el = self.outputs.package.${system} {
-    doomPrivateDir = ./test/doom.d;
-    dependencyOverrides = inputs;
-  };
-  init-example-el-emacsGit = self.outputs.package.${system} {
-    doomPrivateDir = ./test/doom.d;
-    dependencyOverrides = inputs;
+  init-example-el = self.outputs.packages.${system}.nix-doom-emacs;
+  init-example-el-emacsGit = self.outputs.packages.${system}.nix-doom-emacs.override {
     emacsPackages = with pkgs; emacsPackagesFor emacsGit;
   };
 }

--- a/default.nix
+++ b/default.nix
@@ -29,13 +29,13 @@
      See overrides.nix for addition examples.
 
      Example:
-       emacsPackagesOverlay = self: super: {
+       emacsPackagesOverlay = final: prev: {
          magit-delta = super.magit-delta.overrideAttrs (esuper: {
            buildInputs = esuper.buildInputs ++ [ pkgs.git ];
          });
        };
   */
-, emacsPackagesOverlay ? self: super: { }
+, emacsPackagesOverlay ? final: prev: { }
   /* Use bundled revision of github.com/nix-community/emacs-overlay
      as `emacsPackages`.
   */

--- a/flake.nix
+++ b/flake.nix
@@ -92,14 +92,24 @@
     in eachDefaultSystem (system:
       let pkgs = import nixpkgs { inherit system; };
       in {
+        apps = {
+          default = self.outputs.apps.${system}.nix-doom-emacs;
+          nix-doom-emacs = flake-utils.lib.mkApp {
+            drv = self.outputs.packages.${system}.nix-doom-emacs;
+            exePath = "/bin/emacs";
+          };
+        };
+
         devShells.default = pkgs.mkShell {
           buildInputs =
             [ (pkgs.python3.withPackages (ps: with ps; [ PyGithub ])) ];
         };
+
         # TODO: remove this after NixOS 23.05 is released
         package = { ... }@args:
           pkgs.lib.warn "Deprecated, please use `packages.${system}.default` instead!"
           (pkgs.callPackage self args);
+
         packages = {
           default = self.outputs.packages.${system}.nix-doom-emacs;
           nix-doom-emacs = pkgs.callPackage self {

--- a/flake.nix
+++ b/flake.nix
@@ -93,9 +93,9 @@
       let pkgs = import nixpkgs { inherit system; };
       in {
         apps = {
-          default = self.outputs.apps.${system}.nix-doom-emacs;
-          nix-doom-emacs = flake-utils.lib.mkApp {
-            drv = self.outputs.packages.${system}.nix-doom-emacs;
+          default = self.outputs.apps.${system}.doom-emacs;
+          doom-emacs = flake-utils.lib.mkApp {
+            drv = self.outputs.packages.${system}.doom-emacs;
             exePath = "/bin/emacs";
           };
         };
@@ -111,8 +111,8 @@
           (pkgs.callPackage self args);
 
         packages = {
-          default = self.outputs.packages.${system}.nix-doom-emacs;
-          nix-doom-emacs = pkgs.callPackage self {
+          default = self.outputs.packages.${system}.doom-emacs;
+          doom-emacs = pkgs.callPackage self {
             doomPrivateDir = ./test/doom.d;
           };
         };

--- a/flake.nix
+++ b/flake.nix
@@ -107,8 +107,10 @@
 
         package = { ... }@args:
           pkgs.lib.warn ''
-            Deprecated, will be removed after NixOS 23.05 release.
-            Please use `packages.${system}.default` instead!
+            nix-doom-emacs no longer supports the deprecated `package` flake output.
+            It will be removed after the release of NixOS 23.05.
+
+            Please use `packages.${system}.default.override { ... }` instead!
           ''
           (pkgs.callPackage self args);
 

--- a/flake.nix
+++ b/flake.nix
@@ -87,15 +87,15 @@
     flake-compat.flake = false;
   };
 
-  outputs = { self, nixpkgs, flake-utils, emacs-overlay, ... }@inputs:
-    let inherit (flake-utils.lib) eachDefaultSystem eachSystem;
+  outputs = { self, nixpkgs, flake-utils, ... }@inputs:
+    let inherit (flake-utils.lib) eachDefaultSystem mkApp;
     in eachDefaultSystem (system:
       let pkgs = import nixpkgs { inherit system; };
       in {
         apps = {
-          default = self.outputs.apps.${system}.doom-emacs;
-          doom-emacs = flake-utils.lib.mkApp {
-            drv = self.outputs.packages.${system}.doom-emacs;
+          default = self.outputs.apps.${system}.doom-emacs-example;
+          doom-emacs-example = mkApp {
+            drv = self.outputs.packages.${system}.doom-emacs-example;
             exePath = "/bin/emacs";
           };
         };
@@ -105,14 +105,16 @@
             [ (pkgs.python3.withPackages (ps: with ps; [ PyGithub ])) ];
         };
 
-        # TODO: remove this after NixOS 23.05 is released
         package = { ... }@args:
-          pkgs.lib.warn "Deprecated, please use `packages.${system}.default` instead!"
+          pkgs.lib.warn ''
+            Deprecated, will be removed after NixOS 23.05 release.
+            Please use `packages.${system}.default` instead!
+          ''
           (pkgs.callPackage self args);
 
         packages = {
-          default = self.outputs.packages.${system}.doom-emacs;
-          doom-emacs = pkgs.callPackage self {
+          default = self.outputs.packages.${system}.doom-emacs-example;
+          doom-emacs-example = pkgs.callPackage self {
             doomPrivateDir = ./test/doom.d;
           };
         };

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -65,10 +65,10 @@ in
         package customization.
       '';
       type = with types; overlayType;
-      default = self: super: { };
-      defaultText = "self: super { }";
+      default = final: prev: { };
+      defaultText = "final: prev: { }";
       example = literalExample ''
-        self: super: {
+        final: prev: {
           magit-delta = super.magit-delta.overrideAttrs (esuper: {
             buildInputs = esuper.buildInputs ++ [ pkgs.git ];
           });

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -65,8 +65,8 @@ in
         package customization.
       '';
       type = with types; overlayType;
-      default = self: super: {  };
-      defaultText = "self: super {  }";
+      default = self: super: { };
+      defaultText = "self: super { }";
       example = literalExample ''
         self: super: {
           magit-delta = super.magit-delta.overrideAttrs (esuper: {

--- a/overrides.nix
+++ b/overrides.nix
@@ -11,7 +11,7 @@ self: super: {
   doom-snippets = self.straightBuild {
     pname = "doom-snippets";
     postInstall = ''
-       cp -r *-mode $out/share/emacs/site-lisp
+      cp -r *-mode $out/share/emacs/site-lisp
     '';
   };
 


### PR DESCRIPTION
- Small formatting fixes
- Rename output `devShell` -> `devShells.default`
- Add `packages.${system}.nix-doom-emacs` and its alias `packages.${system}.default` as outputs
- Deprecate old `package.${system}` output. This was deprecated in a few versions ago in nix, and also our usage of it was completely non-standard (e.g.: it was a function instead of derivation). **This will be removed soon** (my target is NixOS 23.05 release)
- Refactor tests to use `packages.${system}.nix-doom-emacs`, now that it is a proper derivation
- Add `apps.${system}` output

This refactor has a few nice things:
- People can try `nix-doom-emacs` without needing to install anything (`nix run .`)
- `nix flake show` complains less :P