### PR TITLE
Add `doomPackageDir` argument.

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -108,3 +108,38 @@ jobs:
       if: ${{ !steps.cache-nix-store-emacsGit.outputs.cache-hit }}
       run: |
         nix-store --export $(nix-store -qR /nix/store/*-doom-emacs) > nix-store.dump
+  check-splitdir:
+    name: Flake Check splitdir (x86_64 only)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+          # Nix Flakes doesn't work on shallow clones
+          fetch-depth: 0
+    - uses: cachix/install-nix-action@v17
+      with:
+        extra_nix_config: |
+          extra-substituters = https://nix-community.cachix.org
+          extra-trusted-public-keys = nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=
+    - name: Retrieve /nix/store archive
+      uses: actions/cache@v3
+      id: cache-nix-store
+      with:
+        path: nix-store.dump
+        key: nix-store-${{ hashFiles('flake.lock') }}
+        restore-keys: |
+          nix-store-
+    - name: Import /nix/store contents
+      if: ${{ steps.cache-nix-store.outputs.cache-hit }}
+      run: |
+        if [[ -f nix-store.dump ]]; then
+          nix-store --import < nix-store.dump || true
+          rm nix-store.dump
+        fi
+    - name: Run checks in emacs
+      run: |
+        nix build .#checks.x86_64-linux.init-example-el-splitdir
+    - name: Export /nix/store contents
+      if: ${{ !steps.cache-nix-store.outputs.cache-hit }}
+      run: |
+        nix-store --export $(nix-store -qR /nix/store/*-doom-emacs) > nix-store.dump

--- a/checks.nix
+++ b/checks.nix
@@ -41,4 +41,26 @@ in
     dependencyOverrides = inputs;
     emacsPackages = with pkgs; emacsPackagesFor emacsGit;
   };
+  init-example-el-splitdir = self.outputs.package.${system} {
+    dependencyOverrides = inputs;
+    doomPrivateDir = pkgs.linkFarm "my-doom-packages" [
+         { name = "config.el"; path = ./test/doom.d/config.el; }
+         { name = "init.el"; path = ./test/doom.d/init.el; }
+         # Should *not* fail because we're building our straight environment
+         # using the doomPackageDir, not the doomPrivateDir.
+         {
+           name = "packages.el";
+           path = pkgs.writeText "packages.el" "(package! not-a-valid-package)";
+         }
+       ];
+    doomPackageDir = pkgs.linkFarm "my-doom-packages" [
+         # straight needs a (possibly empty) `config.el` file to build
+         { name = "config.el"; path = pkgs.emptyFile; }
+         { name = "init.el"; path = ./test/doom.d/init.el; }
+         {
+           name = "packages.el";
+           path = pkgs.writeText "packages.el" "(package! inheritenv)";
+         }
+       ];
+  };
 }

--- a/default.nix
+++ b/default.nix
@@ -13,11 +13,14 @@
          # straight needs a (possibly empty) `config.el` file to build
          { name = "config.el"; path = pkgs.emptyFile; }
          { name = "init.el"; path = ./doom.d/init.el; }
-         { name = "packages.el"; path = pkgs.writeText "(package! inheritenv)"; }
+         {
+           name = "packages.el";
+           path = pkgs.writeText "packages.el" "(package! inheritenv)";
+         }
          { name = "modules"; path = ./my-doom-module; }
        ];
    */
-,  doomPackageDir ? null
+,  doomPackageDir ? doomPrivateDir
   /* Extra packages to install
 
      Useful for non-emacs packages containing emacs bindings (e.g.
@@ -123,8 +126,6 @@ let
   # Bundled version of `emacs-overlay`
   emacs-overlay = import (lock "emacs-overlay") pkgs pkgs;
 
-  doomPackageInstallDir = if doomPackageDir == null then doomPrivateDir else doomPackageDir;
-
   # Stage 2: install dependencies and byte-compile prepared source
   doomLocal = let
     straight-env = pkgs.callPackage (lock "nix-straight") {
@@ -146,7 +147,7 @@ let
       phases = [ "installPhase" ];
       nativeBuildInputs = [ git ];
       preInstall = ''
-        export DOOMDIR=${doomPackageInstallDir}
+        export DOOMDIR=${doomPackageDir}
         export DOOMLOCALDIR=$(mktemp -d)/local/
       '';
     });
@@ -164,7 +165,7 @@ let
     phases = [ "installPhase" ];
     nativeBuildInputs = [ git ];
     preInstall = ''
-      export DOOMDIR=${doomPackageInstallDir}
+      export DOOMDIR=${doomPackageDir}
       export DOOMLOCALDIR=$out/
 
       # Create a bogus $HOME directory because gccEmacs is known to require

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,23 @@
 { # The files would be going to ~/.config/doom (~/.doom.d)
   doomPrivateDir
+  /* A Doom configuration directory from which to build the Emacs package environment.
+
+     Can be used, for instance, to prevent rebuilding the Emacs environment
+     each time the `config.el` changes.
+
+     Can be provided as a directory or derivation. If not given, package
+     environment is built against `doomPrivateDir`.
+
+     Example:
+       doomPackageDir = pkgs.linkFarm "my-doom-packages" [
+         # straight needs a (possibly empty) `config.el` file to build
+         { name = "config.el"; path = pkgs.emptyFile; }
+         { name = "init.el"; path = ./doom.d/init.el; }
+         { name = "packages.el"; path = pkgs.writeText "(package! inheritenv)"; }
+         { name = "modules"; path = ./my-doom-module; }
+       ];
+   */
+,  doomPackageDir ? null
   /* Extra packages to install
 
      Useful for non-emacs packages containing emacs bindings (e.g.
@@ -105,6 +123,8 @@ let
   # Bundled version of `emacs-overlay`
   emacs-overlay = import (lock "emacs-overlay") pkgs pkgs;
 
+  doomPackageInstallDir = if doomPackageDir == null then doomPrivateDir else doomPackageDir;
+
   # Stage 2: install dependencies and byte-compile prepared source
   doomLocal = let
     straight-env = pkgs.callPackage (lock "nix-straight") {
@@ -126,7 +146,7 @@ let
       phases = [ "installPhase" ];
       nativeBuildInputs = [ git ];
       preInstall = ''
-        export DOOMDIR=${doomPrivateDir}
+        export DOOMDIR=${doomPackageInstallDir}
         export DOOMLOCALDIR=$(mktemp -d)/local/
       '';
     });
@@ -144,7 +164,7 @@ let
     phases = [ "installPhase" ];
     nativeBuildInputs = [ git ];
     preInstall = ''
-      export DOOMDIR=${doomPrivateDir}
+      export DOOMDIR=${doomPackageInstallDir}
       export DOOMLOCALDIR=$out/
 
       # Create a bogus $HOME directory because gccEmacs is known to require

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -22,6 +22,27 @@ in
       '';
       apply = path: if lib.isStorePath path then path else builtins.path { inherit path; };
     };
+    doomPackageDir = mkOption {
+      description = ''
+        A Doom configuration directory from which to build the Emacs package environment.
+
+        Can be used, for instance, to prevent rebuilding the Emacs environment
+        each time the `config.el` changes.
+
+        Can be provided as a directory or derivation. If not given, package
+        environment is built against `doomPrivateDir`.
+      '';
+      apply = path: if lib.isStorePath path then path else builtins.path { inherit path; };
+      example = literalExample ''
+       doomPackageDir = pkgs.linkFarm "my-doom-packages" [
+           # straight needs a (possibly empty) `config.el` file to build
+           { name = "config.el"; path = pkgs.emptyFile; }
+           { name = "init.el"; path = ./doom.d/init.el; }
+           { name = "packages.el"; path = pkgs.writeText "(package! inheritenv)"; }
+           { name = "modules"; path = ./my-doom-module; }
+         ];
+       '';
+    };
     extraConfig = mkOption {
       description = ''
         Extra configuration options to pass to doom-emacs.

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -34,7 +34,7 @@ in
       '';
       apply = path: if lib.isStorePath path then path else builtins.path { inherit path; };
       example = literalExample ''
-       doomPackageDir = pkgs.linkFarm "my-doom-packages" [
+        doomPackageDir = pkgs.linkFarm "my-doom-packages" [
            # straight needs a (possibly empty) `config.el` file to build
            { name = "config.el"; path = pkgs.emptyFile; }
            { name = "init.el"; path = ./doom.d/init.el; }


### PR DESCRIPTION
This is a directory used for initializing the straight environment, distinct from `doomPrivateDir`. If not given, `doomPrivateDir` is used.

Here it is in action:

https://github.com/znewman01/dotfiles/blob/be9f3a24c517a4ff345f213bf1cf7633713c9278/emacs/default.nix#L12-L34

Fixes #297 (there are some ideas for extra sugar in that issue, but this solves the core problem).