### PR TITLE
Bumps

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,17 +3,17 @@
     "doom-emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1660901074,
-        "narHash": "sha256-3apl0eQlfBj3y0gDdoPp2M6PXYnhxs0QWOHp8B8A9sc=",
+        "lastModified": 1662497747,
+        "narHash": "sha256-4n7E1fqda7cn5/F2jTkOnKw1juG6XMS/FI9gqODL3aU=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "c44bc81a05f3758ceaa28921dd9c830b9c571e61",
+        "rev": "3853dff5e11655e858d0bfae64b70cb12ef685ac",
         "type": "github"
       },
       "original": {
         "owner": "doomemacs",
-        "ref": "master",
         "repo": "doomemacs",
+        "rev": "3853dff5e11655e858d0bfae64b70cb12ef685ac",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,8 @@
   description = "nix-doom-emacs home-manager module";
 
   inputs = {
-    doom-emacs.url = "github:doomemacs/doomemacs/master";
+    # TODO: change back to master once we get synced back with upstream changes
+    doom-emacs.url = "github:doomemacs/doomemacs/3853dff5e11655e858d0bfae64b70cb12ef685ac";
     doom-emacs.flake = false;
     doom-snippets.url = "github:doomemacs/snippets";
     doom-snippets.flake = false;


### PR DESCRIPTION
- Merge all bump PRs except from `doom-emacs`, since the issue from #268 is still not fixed
- Pin commit https://github.com/doomemacs/doomemacs/commit/3853dff5e11655e858d0bfae64b70cb12ef685ac from upstream explicitly. This will at least make the bump bot work again and will give users at least a newer version of upstream