### PR TITLE
fix doomPackageDir in HM module

### DIFF
--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -32,6 +32,7 @@ in
         Can be provided as a directory or derivation. If not given, package
         environment is built against `doomPrivateDir`.
       '';
+      default = cfg.doomPrivateDir;
       apply = path: if lib.isStorePath path then path else builtins.path { inherit path; };
       example = literalExample ''
         doomPackageDir = pkgs.linkFarm "my-doom-packages" [
@@ -106,7 +107,7 @@ in
       emacs = pkgs.callPackage self {
         extraPackages = (epkgs: cfg.extraPackages);
         emacsPackages = pkgs.emacsPackagesFor cfg.emacsPackage;
-        inherit (cfg) doomPrivateDir extraConfig emacsPackagesOverlay;
+        inherit (cfg) doomPrivateDir doomPackageDir extraConfig emacsPackagesOverlay;
         dependencyOverrides = inputs;
       };
     in


### PR DESCRIPTION
I was wondering why the new feature didn't do anything, and discovered that the option wasn't being passed to the derivation. This keeps the same default, but moves it up to the module.
