### PR TITLE
Pin commits

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,17 +3,34 @@
     "doom-emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1660901074,
-        "narHash": "sha256-3apl0eQlfBj3y0gDdoPp2M6PXYnhxs0QWOHp8B8A9sc=",
+        "lastModified": 1662497747,
+        "narHash": "sha256-4n7E1fqda7cn5/F2jTkOnKw1juG6XMS/FI9gqODL3aU=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "c44bc81a05f3758ceaa28921dd9c830b9c571e61",
+        "rev": "3853dff5e11655e858d0bfae64b70cb12ef685ac",
         "type": "github"
       },
       "original": {
         "owner": "doomemacs",
-        "ref": "master",
         "repo": "doomemacs",
+        "rev": "3853dff5e11655e858d0bfae64b70cb12ef685ac",
+        "type": "github"
+      }
+    },
+    "doom-modeline": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1648449595,
+        "narHash": "sha256-HjULFxtNDAJ7PDpy/e2bhoDYgBjwGpBdBoTY135puYA=",
+        "owner": "seagle0128",
+        "repo": "doom-modeline",
+        "rev": "ce9899f00af40edb78f58b9af5c3685d67c8eed2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "seagle0128",
+        "repo": "doom-modeline",
+        "rev": "ce9899f00af40edb78f58b9af5c3685d67c8eed2",
         "type": "github"
       }
     },
@@ -339,6 +356,7 @@
     "root": {
       "inputs": {
         "doom-emacs": "doom-emacs",
+        "doom-modeline": "doom-modeline",
         "doom-snippets": "doom-snippets",
         "emacs-overlay": "emacs-overlay",
         "emacs-so-long": "emacs-so-long",

--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,9 @@
     # TODO: change back to master once we get synced back with upstream changes
     doom-emacs.url = "github:doomemacs/doomemacs/3853dff5e11655e858d0bfae64b70cb12ef685ac";
     doom-emacs.flake = false;
+    # TODO remove pin once we get synced back with upstream changes
+    doom-modeline.url = "github:seagle0128/doom-modeline/ce9899f00af40edb78f58b9af5c3685d67c8eed2";
+    doom-modeline.flake = false;
     doom-snippets.url = "github:doomemacs/snippets";
     doom-snippets.flake = false;
     emacs-overlay.url = "github:nix-community/emacs-overlay";

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,8 @@
   description = "nix-doom-emacs home-manager module";
 
   inputs = {
-    doom-emacs.url = "github:doomemacs/doomemacs/master";
+    # TODO: change back to master once we get synced back with upstream changes
+    doom-emacs.url = "github:doomemacs/doomemacs/3853dff5e11655e858d0bfae64b70cb12ef685ac";
     doom-emacs.flake = false;
     doom-snippets.url = "github:doomemacs/snippets";
     doom-snippets.flake = false;

--- a/overrides.nix
+++ b/overrides.nix
@@ -8,6 +8,15 @@ self: super: {
     buildPhase = ":";
   } // args);
 
+  doom-modeline = self.straightBuild {
+    pname = "doom-modeline";
+    propagatedBuildInputs = with self; [
+      all-the-icons
+      compat
+      shrink-path
+    ];
+  };
+
   doom-snippets = self.straightBuild {
     pname = "doom-snippets";
     postInstall = ''


### PR DESCRIPTION
Replacement of: https://github.com/nix-community/nix-doom-emacs/pull/308

- Pin commit https://github.com/doomemacs/doomemacs/commit/3853dff5e11655e858d0bfae64b70cb12ef685ac from upstream explicitly. This will at least make the bump bot work again and will give users at least a newer version of upstream
- Pin commit https://github.com/seagle0128/doom-modeline/commit/ce9899f00af40edb78f58b9af5c3685d67c8eed2 to fix issue #309.