### PR TITLE
Workaround doom-modeline issues

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -217,6 +217,7 @@ let
     chmod u+w $out/config.el
     cat $extraConfigPath > $out/config.extra.el
     cat > $out/config.el << EOF
+    (load "${./workarounds.el}")
     (load "${doomPrivateDir}/config.el")
     (load "$out/config.extra.el")
     EOF

--- a/flake.lock
+++ b/flake.lock
@@ -17,23 +17,6 @@
         "type": "github"
       }
     },
-    "doom-modeline": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1648449595,
-        "narHash": "sha256-HjULFxtNDAJ7PDpy/e2bhoDYgBjwGpBdBoTY135puYA=",
-        "owner": "seagle0128",
-        "repo": "doom-modeline",
-        "rev": "ce9899f00af40edb78f58b9af5c3685d67c8eed2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "seagle0128",
-        "repo": "doom-modeline",
-        "rev": "ce9899f00af40edb78f58b9af5c3685d67c8eed2",
-        "type": "github"
-      }
-    },
     "doom-snippets": {
       "flake": false,
       "locked": {
@@ -356,7 +339,6 @@
     "root": {
       "inputs": {
         "doom-emacs": "doom-emacs",
-        "doom-modeline": "doom-modeline",
         "doom-snippets": "doom-snippets",
         "emacs-overlay": "emacs-overlay",
         "emacs-so-long": "emacs-so-long",

--- a/flake.nix
+++ b/flake.nix
@@ -39,9 +39,6 @@
     # TODO: change back to master once we get synced back with upstream changes
     doom-emacs.url = "github:doomemacs/doomemacs/3853dff5e11655e858d0bfae64b70cb12ef685ac";
     doom-emacs.flake = false;
-    # TODO remove pin once we get synced back with upstream changes
-    doom-modeline.url = "github:seagle0128/doom-modeline/ce9899f00af40edb78f58b9af5c3685d67c8eed2";
-    doom-modeline.flake = false;
     doom-snippets.url = "github:doomemacs/snippets";
     doom-snippets.flake = false;
     emacs-overlay.url = "github:nix-community/emacs-overlay";

--- a/overrides.nix
+++ b/overrides.nix
@@ -8,15 +8,6 @@ self: super: {
     buildPhase = ":";
   } // args);
 
-  doom-modeline = self.straightBuild {
-    pname = "doom-modeline";
-    propagatedBuildInputs = with self; [
-      all-the-icons
-      compat
-      shrink-path
-    ];
-  };
-
   doom-snippets = self.straightBuild {
     pname = "doom-snippets";
     postInstall = ''

--- a/workarounds.el
+++ b/workarounds.el
@@ -1,0 +1,57 @@
+;;; workarounds.el --- Description -*- lexical-binding: t; -*-
+;;; Re-added functions removed in https://github.com/seagle0128/doom-modeline/commit/b596440ee78b3e7d2debc3d73f4d938d968fb896
+
+;;;###autoload
+(defun doom-modeline-set-minimal-modeline ()
+  "Set minimal mode-line."
+  (doom-modeline-set-modeline 'minimal))
+
+;;;###autoload
+(defun doom-modeline-set-special-modeline ()
+  "Set special mode-line."
+  (doom-modeline-set-modeline 'special))
+
+;;;###autoload
+(defun doom-modeline-set-project-modeline ()
+  "Set project mode-line."
+  (doom-modeline-set-modeline 'project))
+
+;;;###autoload
+(defun doom-modeline-set-dashboard-modeline ()
+  "Set dashboard mode-line."
+  (doom-modeline-set-modeline 'dashboard))
+
+;;;###autoload
+(defun doom-modeline-set-vcs-modeline ()
+  "Set vcs mode-line."
+  (doom-modeline-set-modeline 'vcs))
+
+;;;###autoload
+(defun doom-modeline-set-info-modeline ()
+  "Set Info mode-line."
+  (doom-modeline-set-modeline 'info))
+
+;;;###autoload
+(defun doom-modeline-set-package-modeline ()
+  "Set package mode-line."
+  (doom-modeline-set-modeline 'package))
+
+;;;###autoload
+(defun doom-modeline-set-media-modeline ()
+  "Set media mode-line."
+  (doom-modeline-set-modeline 'media))
+
+;;;###autoload
+(defun doom-modeline-set-message-modeline ()
+  "Set message mode-line."
+  (doom-modeline-set-modeline 'message))
+
+;;;###autoload
+(defun doom-modeline-set-pdf-modeline ()
+  "Set pdf mode-line."
+  (doom-modeline-set-modeline 'pdf))
+
+;;;###autoload
+(defun doom-modeline-set-org-src-modeline ()
+  "Set org-src mode-line."
+  (doom-modeline-set-modeline 'org-src))


### PR DESCRIPTION
- Some clean-ups backported from #316.
- Remove `doom-modeline` pin and re-added missing functions as suggested in https://github.com/nix-community/nix-doom-emacs/issues/309#issuecomment-1288177426. The reason for this is because trying to keep track of `doom-modeline` and the changes in other packages will mean that we will eventually need to pin many packages to its own working version (see #325), while just restoring the missing functions will mean that we (theoretically) can just use the most up-to-date version of `doom-modeline` instead. At least until `doom-modeline` does another breaking change, that is