### PR TITLE
Fix incomplete `Info-directory-list`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -217,7 +217,7 @@ let
     chmod u+w $out/config.el
     cat $extraConfigPath > $out/config.extra.el
     cat > $out/config.el << EOF
-    (load "${./workarounds.el}")
+    (load "${./doom-modeline-workarounds.el}")
     (load "${doomPrivateDir}/config.el")
     (load "$out/config.extra.el")
     EOF
@@ -234,6 +234,7 @@ let
       ''}
       (load "${doom-emacs}/lisp/doom.el")
       (load "${doom-emacs}/lisp/doom-start.el")
+      (load "${./info-workarounds.el}")
     '';
   in (emacsPackages.emacsWithPackages (epkgs: [ load-config-from-site ]));
 

--- a/doom-modeline-workarounds.el
+++ b/doom-modeline-workarounds.el
@@ -1,4 +1,4 @@
-;;; workarounds.el --- Description -*- lexical-binding: t; -*-
+;;; doom-modeline-workarounds.el --- Description -*- lexical-binding: t; -*-
 ;;; Re-added functions removed in https://github.com/seagle0128/doom-modeline/commit/b596440ee78b3e7d2debc3d73f4d938d968fb896
 
 ;;;###autoload

--- a/info-workarounds.el
+++ b/info-workarounds.el
@@ -1,0 +1,3 @@
+;;; info-workarounds.el --- Description -*- lexical-binding: t; -*-
+(push "/usr/share/info" Info-directory-list)
+(push "~/.nix-profile/share/info" Info-directory-list)

--- a/info-workarounds.el
+++ b/info-workarounds.el
@@ -1,3 +1,10 @@
 ;;; info-workarounds.el --- Description -*- lexical-binding: t; -*-
+;;; This file allows the `info` function to find other `info` files in the system.
+
+;;; For non-NixOS GNU/Linux
 (push "/usr/share/info" Info-directory-list)
+
+;;; For NixOS
+(push "/run/current-system/sw/share/info" Info-directory-list)
+
 (push "~/.nix-profile/share/info" Info-directory-list)


### PR DESCRIPTION
Allow system info directories to be found by Emacs' `info` function.