### PR TITLE
fix: add evil-collection to overrides

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -53,6 +53,8 @@
     evil-org-mode.flake = false;
     evil-quick-diff.url = "github:rgrinberg/evil-quick-diff";
     evil-quick-diff.flake = false;
+    evil-collection.url = "github:emacs-evil/evil-collection";
+    evil-collection.flake = false;
     explain-pause-mode.url = "github:lastquestion/explain-pause-mode";
     explain-pause-mode.flake = false;
     format-all.url = "github:lassik/emacs-format-all-the-code/47d862d40a088ca089c92cd393c6dca4628f87d3";

--- a/overrides.nix
+++ b/overrides.nix
@@ -32,6 +32,10 @@ self: super: {
     pname = "evil-quick-diff";
   };
 
+  evil-collection = self.straightBuild {
+    pname = "evil-collection";
+  };
+
   magit = super.magit.overrideAttrs (esuper: {
     preBuild = ''
       make VERSION="${esuper.version}" -C lisp magit-version.el


### PR DESCRIPTION
When installing `nix-doom-emacs` on a macOS m2 machine (Ventura 13.4), the build process hangs when processing the `evil-collection` package.

Adding this override fixes the problem.