### PR TITLE
feat: add doomModules option

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -125,6 +125,7 @@
         };
         checks = import ./checks.nix { inherit system; } inputs;
       }) // {
+        lib = import ./lib.nix;
         hmModule = import ./modules/home-manager.nix inputs;
       };
 }

--- a/lib.nix
+++ b/lib.nix
@@ -1,0 +1,49 @@
+{
+
+  /* This function creates a derivation that injects a `modules` folder (containing the
+     directories in the `src` parameter) into a doom.d configuration folder.
+  */
+  mkDoomModules = pkgs: {
+    name,
+    version,
+    src,
+    meta ? {},
+
+    literateCode ? false
+  } @ args: pkgs.stdenvNoCC.mkDerivation {
+    inherit name version meta;
+
+    src = pkgs.lib.sourceFilesBySuffices src [ ".el" ".org" ];
+
+    buildInputs =
+      if literateCode then
+        [ pkgs.emacs pkgs.coreutils ]
+      else
+        [];
+
+    buildPhase =
+      # transform literate code into .el files
+      if literateCode then
+        ''
+          cp -R $src/* .
+          chmod -R 700 .
+
+          # Traverse the directory and execute the command on each '.org' file
+          find . -type f -name "*.org" -print0 | while IFS= read -r -d "" file; do
+            echo "tangle file $file"
+            emacs --batch -Q -l org \
+              --eval "(org-babel-tangle-file \"$file\" \"''${file%.*}.el\")"
+          done
+
+          chmod -R 700 .
+        ''
+      else
+        "";
+
+    installPhase = ''
+        mkdir -p $out/modules
+        ${pkgs.rsync}/bin/rsync -av . $out/modules
+    '';
+  };
+
+}

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -22,6 +22,27 @@ in
       '';
       apply = path: if lib.isStorePath path then path else builtins.path { inherit path; };
     };
+    doomModules = mkOption {
+      description = ''
+        A set of derivations that build a `modules` directory that are included
+        to your Doom configuration.
+
+        Can be used to install doom modules that get built using the
+        `nix-doom-emacs.lib.mkDoomModules` function.
+      '';
+      default = [];
+      example = literalExample ''
+        doomModules =
+          let
+            myDoomModule = inputs.nix-doom-emacs.lib.mkDoomModules {
+              name = "my-doom-module";
+              src  = ./modules;
+              literateCode = true;
+            };
+          in
+           [ myDoomModule ]
+      '';
+    };
     doomPackageDir = mkOption {
       description = ''
         A Doom configuration directory from which to build the Emacs package environment.
@@ -107,7 +128,7 @@ in
       emacs = pkgs.callPackage self {
         extraPackages = (epkgs: cfg.extraPackages);
         emacsPackages = pkgs.emacsPackagesFor cfg.emacsPackage;
-        inherit (cfg) doomPrivateDir doomPackageDir extraConfig emacsPackagesOverlay;
+        inherit (cfg) doomPrivateDir doomPackageDir doomModules extraConfig emacsPackagesOverlay;
         dependencyOverrides = inputs;
       };
     in


### PR DESCRIPTION
### Context

As a doom-emacs user
I want to distribute my doom modules as nix derivations
So that I can include them in multiple configurations of doom.d that do not require my personal config

### Rationale

I would like to have a way to offer my personal doom-emacs modules as a git repository that later can be included in `nix-doom-emacs` installation. By using the new `lib.mkDoomModules`, I can easily create a derivation that contains the modules I want included on a doom.d folder that gets constructed using `nix-doom-emacs`.
