### PR TITLE
fix: rm evil-collection from overrides

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -66,22 +66,6 @@
         "type": "github"
       }
     },
-    "evil-collection": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1686801899,
-        "narHash": "sha256-wGJWF9t8yaxLyYQRf3hK+5/AIYYAS8qWXPDEvatzBlc=",
-        "owner": "emacs-evil",
-        "repo": "evil-collection",
-        "rev": "4a7d924dbd851ef1b2ccb85778be6e7a6a81ebd4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "emacs-evil",
-        "repo": "evil-collection",
-        "type": "github"
-      }
-    },
     "evil-escape": {
       "flake": false,
       "locked": {
@@ -362,7 +346,6 @@
         "doom-snippets": "doom-snippets",
         "emacs-overlay": "emacs-overlay",
         "emacs-so-long": "emacs-so-long",
-        "evil-collection": "evil-collection",
         "evil-escape": "evil-escape",
         "evil-markdown": "evil-markdown",
         "evil-org-mode": "evil-org-mode",

--- a/flake.nix
+++ b/flake.nix
@@ -53,8 +53,6 @@
     evil-org-mode.flake = false;
     evil-quick-diff.url = "github:rgrinberg/evil-quick-diff";
     evil-quick-diff.flake = false;
-    evil-collection.url = "github:emacs-evil/evil-collection";
-    evil-collection.flake = false;
     explain-pause-mode.url = "github:lastquestion/explain-pause-mode";
     explain-pause-mode.flake = false;
     format-all.url = "github:lassik/emacs-format-all-the-code/47d862d40a088ca089c92cd393c6dca4628f87d3";

--- a/overrides.nix
+++ b/overrides.nix
@@ -32,10 +32,6 @@ self: super: {
     pname = "evil-quick-diff";
   };
 
-  evil-collection = self.straightBuild {
-    pname = "evil-collection";
-  };
-
   magit = super.magit.overrideAttrs (esuper: {
     preBuild = ''
       make VERSION="${esuper.version}" -C lisp magit-version.el


### PR DESCRIPTION
This change was added to allow evil-collection to compile on latest versions macOS Ventura, the evil-collection version at the time of this change was halting on the compilation of the `evil-collection-speedbar.el` file.

Unfortunately, although this approach finishes the nix-doom emacs compilation, it leaves doom-emacs' runtime in a faulty state. The emacs package relies on a sub-directory `modes` that doesn't get compiled when specifying this dependency in the overrides list.

Users should override the `emacsPackagesOverlay` option and specify the `evil-collection` variable to make it work as expected on macOS Ventura. Following an example

```nix
{ pkgs, ... }:
{
  programs.doom-emacs = {
    enable = true;
    emacsPackagesOverlay = _final: _prev: {
        inherit (pkgs.emacsPackages) evil-collection;
    };
  };
}
```